### PR TITLE
Add 1 hour delay if Imgur returns upload error

### DIFF
--- a/stop_watcher.py
+++ b/stop_watcher.py
@@ -375,10 +375,15 @@ def write_gyms(cursor, config):
                         f.write(var + "\n")
 
 def imgur(static_map, config):
-    im = pyimgur.Imgur(config['client_id_imgur'])
-    uploaded_image = im.upload_image(url=static_map)
-    static_map = (uploaded_image.link)
-    return static_map
+    try:
+        im = pyimgur.Imgur(config['client_id_imgur'])
+        uploaded_image = im.upload_image(url=static_map)
+        static_map = (uploaded_image.link)
+        return static_map
+    except:
+        print("Imgur error. Sleeping 1 hour")
+        time.sleep(3600)
+        return
 
 def generate_static_map(poitype, lat, lon, config):
     if config['static_provider'] == "google":

--- a/stop_watcher.py
+++ b/stop_watcher.py
@@ -376,7 +376,7 @@ def write_gyms(cursor, config):
 
 def imgur(static_map, config):
     imgursuccess = 0
-    while imgursuccess = 0
+    while imgursuccess == 0:
         try:
             im = pyimgur.Imgur(config['client_id_imgur'])
             uploaded_image = im.upload_image(url=static_map)

--- a/stop_watcher.py
+++ b/stop_watcher.py
@@ -375,15 +375,17 @@ def write_gyms(cursor, config):
                         f.write(var + "\n")
 
 def imgur(static_map, config):
-    try:
-        im = pyimgur.Imgur(config['client_id_imgur'])
-        uploaded_image = im.upload_image(url=static_map)
-        static_map = (uploaded_image.link)
-        return static_map
-    except:
-        print("Imgur error. Sleeping 1 hour")
-        time.sleep(3600)
-        return
+    imgursuccess = 0
+    while imgursuccess = 0
+        try:
+            im = pyimgur.Imgur(config['client_id_imgur'])
+            uploaded_image = im.upload_image(url=static_map)
+            static_map = (uploaded_image.link)
+            imgursuccess = 1
+        except:
+            print("Imgur error. Sleeping 1 hour")
+            time.sleep(3600)
+    return static_map
 
 def generate_static_map(poitype, lat, lon, config):
     if config['static_provider'] == "google":


### PR DESCRIPTION
Standard upload ratelimit if more than 50 images are uploaded at once. Useful if there is a lapse in scraping/scanning and you have alot of webhooks to send.