### PR TITLE
feat: Add basic docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+config_example
+config
+Dockerfile
+docker-compose.yml
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+# docker build -t stopwatcher .
+# docker run --rm -v "$(pwd)"/config:/usr/src/app/config -t stopwatcher python3 stop_watcher.py --init
+# docker run --rm -v "$(pwd)"/config:/usr/src/app/config -t stopwatcher
+
+FROM python:3.7-slim
+WORKDIR /usr/src/app
+COPY . .
+RUN python3 -m pip install --no-cache-dir -r requirements.txt
+
+CMD ["python3","stop_watcher.py"]


### PR DESCRIPTION
Instructions are included in the Dockerfile. Users can extend on this
and use more advanced setups like docker swarm, docker-compose, etc in
order to schedule stopwatcher runs.