### PR TITLE
add text to new portal if its already a stop or gym

### DIFF
--- a/locale/de.json
+++ b/locale/de.json
@@ -27,5 +27,7 @@
     "stays_no_stop": "❌ Bleibt kein Stop",
     "cell_becomes_empty": "✅ Wird leer",
     "cell_stays_occupied": "❌ Bleibt belegt",
-    "gets_new_stop": "✅ Bekommt einen neuen Stop"
+    "gets_new_stop": "✅ Bekommt einen neuen Stop",
+	"already_stop": "✅ Portal ist bereits ein Stop",
+	"already_gym": "✅ Portal ist bereits eine Arena"
 }

--- a/locale/en.json
+++ b/locale/en.json
@@ -27,5 +27,7 @@
     "stays_no_stop": "❌ Keeps being no Stop",
     "cell_becomes_empty": "✅ Becomes empty",
     "cell_stays_occupied": "❌ Stays occupied",
-    "gets_new_stop": "✅ Gets a new Stop"
+    "gets_new_stop": "✅ Gets a new Stop",
+	"already_stop": "✅ Portal is already a Stop",
+	"already_gym": "✅ Portal is already a Gym"
 }

--- a/locale/es.json
+++ b/locale/es.json
@@ -28,5 +28,7 @@
     "stays_no_stop": "❌ Sigue sin ser una Poképarada",
     "cell_becomes_empty": "✅ Queda vacía",
     "cell_stays_occupied": "❌ Queda ocupada",
-    "gets_new_stop": "✅ Obtiene una nueva Poképarada"
+    "gets_new_stop": "✅ Obtiene una nueva Poképarada",
+	"already_stop": "✅ Portal is already a Stop",
+	"already_gym": "✅ Portal is already a Gym"
 }

--- a/locale/fr.json
+++ b/locale/fr.json
@@ -28,5 +28,7 @@
     "stays_no_stop": "❌ Ne sera pas un PokéStop",
     "cell_becomes_empty": "✅ Devient vide",
     "cell_stays_occupied": "❌ Reste occupée",
-    "gets_new_stop": "✅ Deviendra un PokéStop"
+    "gets_new_stop": "✅ Deviendra un PokéStop",
+	"already_stop": "✅ Portal is already a Stop",
+	"already_gym": "✅ Portal is already a Gym"
 }

--- a/locale/pl.json
+++ b/locale/pl.json
@@ -28,5 +28,7 @@
     "stays_no_stop": "❌ Nadal nie będzie Pokestopem",
     "cell_becomes_empty": "✅ Będzie pusta",
     "cell_stays_occupied": "❌ Pozostaje zajęta",
-    "gets_new_stop": "✅ Powstanie nowy Pokestop"
+    "gets_new_stop": "✅ Powstanie nowy Pokestop",
+	"already_stop": "✅ Portal is already a Stop",
+	"already_gym": "✅ Portal is already a Gym"
 }

--- a/stop_watcher.py
+++ b/stop_watcher.py
@@ -159,7 +159,18 @@ for fil in config.filters:
             for p_id, p_lat, p_lon, p_name, p_img in portals:
                 if not p_id in portal_cache:
                     portal = waypoint(queries, config, "portal", p_id, p_name, p_img, p_lat, p_lon)
-                    portal.send(fil)
+                    if "dont_send_if_already_exists_as_stop_or_gym" in fil:
+                        if fil["dont_send_if_already_exists_as_stop_or_gym"]:
+                            if queries.get_stop_by_id(p_id):
+                                print(f"Found portal {p_name} - not sending because portal is already a stop")
+                            elif queries.get_gym_by_id(p_id):
+                                print(f"Found portal {p_name} - not sending because portal is already a gym")
+                            else:
+                                portal.send(fil)
+                        else:
+                            portal.send(fil)
+                    else:
+                        portal.send(fil)
                     if not portal.id in new_portal_cache:
                         new_portal_cache.append(p_id)
             with open("config/cache/portals.json", "w", encoding="utf-8") as f:

--- a/util/waypoints.py
+++ b/util/waypoints.py
@@ -123,24 +123,31 @@ class waypoint():
                 stop_cell = s2cell(self.queries, self.lat, self.lon, 17)
 
                 if not self.edit:
-                    gym_cell = s2cell(self.queries, self.lat, self.lon, 14)
-
-                    if stop_cell.converts():
-                        text = self.locale["will_convert"]
-                        convert_time = self.get_convert_time()
+                    if self.queries.get_stop_by_id(self.id):
+                        text = self.locale["already_stop"]
+                        convert_time = ""
+                    elif self.queries.get_gym_by_id(self.id):
+                        text = self.locale["already_gym"]
+                        convert_time = ""
                     else:
-                        text = self.locale["wont_convert"]
+                        gym_cell = s2cell(self.queries, self.lat, self.lon, 14)
 
-                    if stop_cell.converts() and gym_cell.brings_gym():
-                        text = f"{text}\n{self.locale['brings_gym']}"
-                    else:
-                        text = f"{text}\n{self.locale['brings_no_gym']}"
-
-                    if stop_cell.converts():
-                        if gym_cell.stops > 20:
-                            text = (f"{text}\n{self.locale['x_stop_in_cell_20']}").format(x = gym_cell.stops + 1)
+                        if stop_cell.converts():
+                            text = self.locale["will_convert"]
+                            convert_time = self.get_convert_time()
                         else:
-                            text = (f"{text}\n{self.locale['x_stop_in_cell']}").format(x = gym_cell.stops + 1, total = gym_cell.next_threshold())
+                            text = self.locale["wont_convert"]
+
+                        if stop_cell.converts() and gym_cell.brings_gym():
+                            text = f"{text}\n{self.locale['brings_gym']}"
+                        else:
+                            text = f"{text}\n{self.locale['brings_no_gym']}"
+
+                        if stop_cell.converts():
+                            if gym_cell.stops > 20:
+                                text = (f"{text}\n{self.locale['x_stop_in_cell_20']}").format(x = gym_cell.stops + 1)
+                            else:
+                                text = (f"{text}\n{self.locale['x_stop_in_cell']}").format(x = gym_cell.stops + 1, total = gym_cell.next_threshold())
                     
                     pathjson = f"&pathjson={stop_cell.path}"
                     geojson = f"geojson(%7B%0D%0A%22type%22%3A%22FeatureCollection%22%2C%0D%0A%22features%22%3A%5B%0D%0A%7B%0D%0A%22type%22%3A%22Feature%22%2C%0D%0A%22properties%22%3A%7B%7D%2C%0D%0A%22geometry%22%3A%7B%0D%0A%22type%22%3A%22Polygon%22%2C%0D%0A%22coordinates%22%3A%5B%0D%0A{stop_cell.mapbox_path}%0D%0A%5D%0D%0A%7D%0D%0A%7D%0D%0A%5D%0D%0A%7D)".replace(" ", "").replace("'", "%22").replace("[", "%5B").replace("]", "%5D").replace(",", "%2C")


### PR DESCRIPTION
If a new portal was found, but the stop or gym is already in your database, the notification will say its already a stop or gym. This happens sometimes if your cookie runs out, or your scanner was faster then your ingress scraper. 

![ss (2020-05-12 at 11 29 16)](https://user-images.githubusercontent.com/65044707/81748227-c4c74900-94a9-11ea-9130-ce7837d06f93.jpg)

In addition i added a new option for filters:
`		"dont_send_if_already_exists_as_stop_or_gym": false,
`
if added to filters and set to true, it wont send new portals, which are already a stop or gym. 

implementation is ugly, but it works 

needs pl, fr and es translations