### PR TITLE
Fix mapbox address key error

### DIFF
--- a/util/waypoints.py
+++ b/util/waypoints.py
@@ -253,7 +253,8 @@ class waypoint():
                     if place_type == "address":
                         addressg = feature["place_name"]
                         street = feature["text"]
-                        street_number = feature["address"]
+                        if "address" in feature:
+                            street_number = feature["address"]
                     elif place_type == "locality":
                         suburb = feature["text"]
                     elif place_type == "place":


### PR DESCRIPTION
On some waypoints it's possible that the `address` key doesn't exist when using mapbox, so we should check if it exists before accessing it.

Example: https://api.mapbox.com/geocoding/v5/mapbox.places/7.059724,50.624072.json?language=en&access_token=