### PR TITLE
Fix to close database connection for portals.

### DIFF
--- a/stop_watcher.py
+++ b/stop_watcher.py
@@ -352,6 +352,7 @@ if any("edits" in i for i in config.filters):
 
 cursor.close()
 mydb.close()
+mydb_p.close()
 
 with open("config/cache/edits.json", "w", encoding="utf-8") as f:
     f.write(json.dumps(edit_list, indent=4))


### PR DESCRIPTION
Every run of stopwatcher leaves an aborted connection in the mysql log.  This is due to it not closing the connection to the portals db at the end like it does with the main db.  I have added mydb_p.close() to the end of the script and it now functions properly.