### PR TITLE
V2 - Configurable Removal Time

### DIFF
--- a/config_example/config.ini
+++ b/config_example/config.ini
@@ -1,6 +1,7 @@
 [Config]
 language = en/de/fr/es/pl/pt
 portal_scraper_interval = 3600
+removed_stop_wait = 172800
 
 [Maps]
 static_map = True

--- a/config_example/config.ini
+++ b/config_example/config.ini
@@ -1,7 +1,7 @@
 [Config]
 language = en/de/fr/es/pl/pt
 portal_scraper_interval = 3600
-removed_stop_wait = 172800
+removed_stop_wait = 3600
 
 [Maps]
 static_map = True

--- a/stop_watcher.py
+++ b/stop_watcher.py
@@ -187,7 +187,7 @@ for fil in config.filters:
     deleted_max_portals = 5
     deleted_timespan_portals = ((4*config.scraper_wait) / 60)
     deleted_max_stops = 5
-    deleted_timespan_stops = 300
+    deleted_timespan_stops = ((4*config.removed_wait) / 60)
     if "deleted" in fil:
         if "max" in fil["deleted"]:
             if "scraper" in fil["deleted"]["max"]:

--- a/util/config.py
+++ b/util/config.py
@@ -21,6 +21,7 @@ class create_config:
         self.map_url = config_file.get("Maps", "map_url")
         self.map_provider = config_file.get("Maps", "frontend").lower()
         self.map_name = config_file.get("Maps", "map_name")
+        self.geojson = config_file.getboolean("Maps", "geojson")
 
         self.use_geocoding = config_file.getboolean("Maps", "geocoding")
         self.geocoding_provider = config_file.get("Maps", "geocoding_provider").lower()

--- a/util/config.py
+++ b/util/config.py
@@ -8,7 +8,7 @@ class create_config:
 
         self.language = config_file.get("Config", "language").lower()
         self.scraper_wait = config_file.getint("Config", "portal_scraper_interval")
-        self.removed_wait = config_file.getint("Config", "removed_stop_wait")
+        self.removed_wait = config_file.getint("Config", "removed_stop_wait", fallback=3600)
 
         self.use_static_map = config_file.getboolean("Maps", "static_map")
         self.static_provider = config_file.get("Maps", "static_map_provider").lower()
@@ -21,7 +21,7 @@ class create_config:
         self.map_url = config_file.get("Maps", "map_url")
         self.map_provider = config_file.get("Maps", "frontend").lower()
         self.map_name = config_file.get("Maps", "map_name")
-        self.geojson = config_file.getboolean("Maps", "geojson")
+        self.geojson = config_file.getboolean("Maps", "geojson", fallback= False)
 
         self.use_geocoding = config_file.getboolean("Maps", "geocoding")
         self.geocoding_provider = config_file.get("Maps", "geocoding_provider").lower()

--- a/util/config.py
+++ b/util/config.py
@@ -8,7 +8,7 @@ class create_config:
 
         self.language = config_file.get("Config", "language").lower()
         self.scraper_wait = config_file.getint("Config", "portal_scraper_interval")
-
+        self.removed_wait = config_file.getint("Config", "removed_stop_wait")
 
         self.use_static_map = config_file.getboolean("Maps", "static_map")
         self.static_provider = config_file.get("Maps", "static_map_provider").lower()
@@ -21,7 +21,6 @@ class create_config:
         self.map_url = config_file.get("Maps", "map_url")
         self.map_provider = config_file.get("Maps", "frontend").lower()
         self.map_name = config_file.get("Maps", "map_name")
-        self.geojson = config_file.getboolean("Maps", "geojson")
 
         self.use_geocoding = config_file.getboolean("Maps", "geocoding")
         self.geocoding_provider = config_file.get("Maps", "geocoding_provider").lower()

--- a/util/config.py
+++ b/util/config.py
@@ -8,7 +8,7 @@ class create_config:
 
         self.language = config_file.get("Config", "language").lower()
         self.scraper_wait = config_file.getint("Config", "portal_scraper_interval")
-        self.removed_wait = config_file.getint("Config", "removed_stop_wait", fallback=3600)
+        self.removed_wait = config_file.getint("Config", "removed_stop_wait", fallback=18000)
 
         self.use_static_map = config_file.getboolean("Maps", "static_map")
         self.static_provider = config_file.get("Maps", "static_map_provider").lower()


### PR DESCRIPTION
Description of PR:
Make time stopwatcher considers stop/gyms removed a configurable time.

Reason:
I quest scan a much larger area then I run regular scans on, after questing I would get a lot of false reports of removals.

Solution:
add code to allow value to read from config ini and set default of 48 hours.
